### PR TITLE
Adds yaw based player rotation and gesture triggers fpr jump

### DIFF
--- a/Assets/Scenes/3DcameraPrototype.unity
+++ b/Assets/Scenes/3DcameraPrototype.unity
@@ -171,8 +171,13 @@ MonoBehaviour:
   headZThreshhold: 0.1
   headXThreshold: 0.1
   headRollThreshold: 0.25
+  headYawThreshold: 0.7
   rollSpeed: 50
   invertRotation: 0
+  rotateWithYaw: 1
+  jumpStartAngleThreshold: 15
+  jumpEndAngleThreshold: 35
+  jumpYawThreshold: 10
 --- !u!1 &300924384
 GameObject:
   m_ObjectHideFlags: 0
@@ -787,6 +792,51 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1549025714}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &710335809
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 710335811}
+  - component: {fileID: 710335810}
+  m_Layer: 0
+  m_Name: FPSLock
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &710335810
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 710335809}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 81176e7610ad6db45a457186189ba673, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: '::'
+  targetFPS: 60
+--- !u!4 &710335811
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 710335809}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 36.03587, y: 0, z: 219.7531}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &832575517
 GameObject:
@@ -1622,3 +1672,4 @@ SceneRoots:
   - {fileID: 1549025714}
   - {fileID: 17487671676369494}
   - {fileID: 1348361837}
+  - {fileID: 710335811}

--- a/Assets/Scripts/targetFPS.cs
+++ b/Assets/Scripts/targetFPS.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+public class FPSLimiter : MonoBehaviour
+{
+    public int targetFPS = 60;
+
+    void Awake()
+    {
+        Application.targetFrameRate = targetFPS;
+        // disable VSync to ensure targetFrameRate takes full effect
+        QualitySettings.vSyncCount = 0;
+    }
+}

--- a/Assets/Scripts/targetFPS.cs.meta
+++ b/Assets/Scripts/targetFPS.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 81176e7610ad6db45a457186189ba673

--- a/Assets/TrackIR/Helper Scripts/FollowCam.cs
+++ b/Assets/TrackIR/Helper Scripts/FollowCam.cs
@@ -47,7 +47,7 @@ public class FollowCam : MonoBehaviour
 
     void Update()
     {
-        if(mFirstPersonFollowTarget == null)
+        if (mFirstPersonFollowTarget == null)
         {
             return;
         }
@@ -85,7 +85,8 @@ public class FollowCam : MonoBehaviour
             newRotation.eulerAngles = new Vector3(0f, newRotation.eulerAngles.y, 0f);
             transform.rotation = newRotation;
 
-        }else if(!isThirdPerson)
+        }
+        else if (!isThirdPerson)
         {
             Vector3 targetPosition = mFirstPersonFollowTarget.position + firstPersonCameraOffest;
             transform.position = targetPosition;

--- a/Assets/TrackIR/TrackIR/Client.cs
+++ b/Assets/TrackIR/TrackIR/Client.cs
@@ -85,16 +85,16 @@ namespace NaturalPoint.TrackIR
         /// </summary>
         /// <param name="applicationId">Your NaturalPoint-assigned application ID.</param>
         /// <param name="hwnd">The handle for the foreground window of your application.</param>
-        public Client( UInt16 applicationId, IntPtr hwnd )
+        public Client(UInt16 applicationId, IntPtr hwnd)
         {
-            if ( applicationId == 0 )
+            if (applicationId == 0)
             {
-                throw new ArgumentException( "Application ID cannot be zero." );
+                throw new ArgumentException("Application ID cannot be zero.");
             }
 
-            if ( hwnd == IntPtr.Zero )
+            if (hwnd == IntPtr.Zero)
             {
-                throw new ArgumentException( "hwnd cannot be zero." );
+                throw new ArgumentException("hwnd cannot be zero.");
             }
 
             m_appId = applicationId;
@@ -124,23 +124,23 @@ namespace NaturalPoint.TrackIR
         /// </summary>
         public void Disconnect()
         {
-            if ( m_bDataTransmitting )
+            if (m_bDataTransmitting)
             {
                 NPResult stopDataResult = m_clientLib.NP_StopDataTransmission();
-                if ( stopDataResult != NPResult.OK )
+                if (stopDataResult != NPResult.OK)
                 {
-                    Console.WriteLine( "WARNING: NP_StopDataTransmission returned " + stopDataResult.ToString() + "." );
+                    Console.WriteLine("WARNING: NP_StopDataTransmission returned " + stopDataResult.ToString() + ".");
                 }
 
                 m_bDataTransmitting = false;
             }
 
-            if ( m_bRegisteredWindowHandle )
+            if (m_bRegisteredWindowHandle)
             {
                 NPResult unregisterResult = m_clientLib.NP_UnregisterWindowHandle();
-                if ( unregisterResult != NPResult.OK )
+                if (unregisterResult != NPResult.OK)
                 {
-                    Console.WriteLine( "WARNING: NP_UnregisterWindowHandle returned " + unregisterResult.ToString() + "." );
+                    Console.WriteLine("WARNING: NP_UnregisterWindowHandle returned " + unregisterResult.ToString() + ".");
                 }
 
                 m_bRegisteredWindowHandle = false;
@@ -170,11 +170,11 @@ namespace NaturalPoint.TrackIR
         /// <returns>True if new data was available, false otherwise.</returns>
         public bool UpdatePose()
         {
-            
-            if ( m_bPendingReconnect )
+
+            if (m_bPendingReconnect)
             {
                 // Note: This call could throw.
-                if ( InternalConnect() )
+                if (InternalConnect())
                 {
                     // Successfully reconnected; clear the flag and continue normally.
                     m_bPendingReconnect = false;
@@ -186,8 +186,8 @@ namespace NaturalPoint.TrackIR
                     return false;
                 }
             }
-            
-            NPResult getDataResult = m_clientLib.NP_GetData( ref m_trackirData );
+
+            NPResult getDataResult = m_clientLib.NP_GetData(ref m_trackirData);
             if (m_trackirData.Status == 0)
             {
                 if (getDataResult == NPResult.OK)
@@ -245,19 +245,19 @@ namespace NaturalPoint.TrackIR
             // Clear this flag. Most exit paths from this function represent errors we can't recover from, and we
             // shouldn't keep trying repeatedly; the only exception is waiting for ERR_DEVICE_NOT_PRESENT to resolve.
             m_bPendingReconnect = false;
-			m_clientLib.NP_UnregisterWindowHandle();
+            m_clientLib.NP_UnregisterWindowHandle();
             // Retrieve host software version.
             UInt16 version;
-            NPResult queryVersionResult = m_clientLib.NP_QueryVersion( out version );
-            if ( queryVersionResult == NPResult.ERR_DEVICE_NOT_PRESENT )
+            NPResult queryVersionResult = m_clientLib.NP_QueryVersion(out version);
+            if (queryVersionResult == NPResult.ERR_DEVICE_NOT_PRESENT)
             {
                 // Don't go any further; we'll try to connect again next time UpdatePose is called.
                 m_bPendingReconnect = true;
                 return false;
             }
-            else if ( queryVersionResult != NPResult.OK )
+            else if (queryVersionResult != NPResult.OK)
             {
-                Console.WriteLine( "WARNING: NP_QueryVersion returned " + queryVersionResult.ToString() + "." );
+                Console.WriteLine("WARNING: NP_QueryVersion returned " + queryVersionResult.ToString() + ".");
             }
 
             HostSoftwareVersionMajor = (version >> 8);
@@ -265,49 +265,49 @@ namespace NaturalPoint.TrackIR
 
             // Retrieve signature object and validate that signature strings match expected values.
             TrackIRSignature signature = new TrackIRSignature();
-            NPResult getSignatureResult = m_clientLib.NP_GetSignature( ref signature );
+            NPResult getSignatureResult = m_clientLib.NP_GetSignature(ref signature);
 
-            if ( getSignatureResult != NPResult.OK )
+            if (getSignatureResult != NPResult.OK)
             {
-                throw new TrackIRException( "NP_GetSignature returned " + getSignatureResult.ToString() + "." );
+                throw new TrackIRException("NP_GetSignature returned " + getSignatureResult.ToString() + ".");
             }
 
             const string kExpectedAppSignature = "hardware camera\n software processing data\n track user movement\n\n Copyright EyeControl Technologies";
             const string kExpectedDllSignature = "precise head tracking\n put your head into the game\n now go look around\n\n Copyright EyeControl Technologies";
 
-            if ( signature.AppSignature != kExpectedAppSignature || signature.DllSignature != kExpectedDllSignature )
+            if (signature.AppSignature != kExpectedAppSignature || signature.DllSignature != kExpectedDllSignature)
             {
-                throw new TrackIRException( "Unable to verify TrackIR Enhanced signature values." );
+                throw new TrackIRException("Unable to verify TrackIR Enhanced signature values.");
             }
             //m_clientLib.NP_UnregisterWindowHandle();
             // Register the application window for liveness checks. This allows the TrackIR software to
             // detect situations where e.g. your application crashes and fails to shut down cleanly.
-            NPResult registerHwndResult = m_clientLib.NP_RegisterWindowHandle( m_appHwnd );
-            if ( registerHwndResult == NPResult.OK )
+            NPResult registerHwndResult = m_clientLib.NP_RegisterWindowHandle(m_appHwnd);
+            if (registerHwndResult == NPResult.OK)
             {
                 m_bRegisteredWindowHandle = true;
             }
             else
             {
-                throw new TrackIRException( "NP_RegisterWindowHandle returned " + registerHwndResult.ToString() + "." );
+                throw new TrackIRException("NP_RegisterWindowHandle returned " + registerHwndResult.ToString() + ".");
             }
 
             // Register the application by its NaturalPoint-assigned ID.
-            NPResult registerIdResult = m_clientLib.NP_RegisterProgramProfileID( m_appId );
-            if ( registerIdResult != NPResult.OK )
+            NPResult registerIdResult = m_clientLib.NP_RegisterProgramProfileID(m_appId);
+            if (registerIdResult != NPResult.OK)
             {
-                throw new TrackIRException( "NP_RegisterProgramProfileID returned " + registerIdResult.ToString() + "." );
+                throw new TrackIRException("NP_RegisterProgramProfileID returned " + registerIdResult.ToString() + ".");
             }
 
             // Signal that we want to start receiving tracking data.
             NPResult startDataResult = m_clientLib.NP_StartDataTransmission();
-            if ( startDataResult == NPResult.OK )
+            if (startDataResult == NPResult.OK)
             {
                 m_bDataTransmitting = true;
             }
             else
             {
-                throw new TrackIRException( "NP_StartDataTransmission returned " + startDataResult.ToString() + "." );
+                throw new TrackIRException("NP_StartDataTransmission returned " + startDataResult.ToString() + ".");
             }
 
             return true;
@@ -316,5 +316,5 @@ namespace NaturalPoint.TrackIR
 
 
 
-    
+
 } // namespace NaturalPoint.TrackIR

--- a/Assets/TrackIR/TrackIR/Common.cs
+++ b/Assets/TrackIR/TrackIR/Common.cs
@@ -36,9 +36,9 @@ namespace NaturalPoint.TrackIR
             public float Y;
             public float Z;
 
-            public static readonly Quaternion Identity = new Quaternion( 1.0f, 0.0f, 0.0f, 0.0f );
+            public static readonly Quaternion Identity = new Quaternion(1.0f, 0.0f, 0.0f, 0.0f);
 
-            public Quaternion( float w, float x, float y, float z )
+            public Quaternion(float w, float x, float y, float z)
             {
                 W = w;
                 X = x;
@@ -47,21 +47,21 @@ namespace NaturalPoint.TrackIR
             }
 
             // Returns a quaternion representing Tait-Bryan intrinsic rotation angles in z-y'-x'' sequence.
-            public static Quaternion FromTaitBryanIntrinsicZYX( float zRadians, float yRadians, float xRadians )
+            public static Quaternion FromTaitBryanIntrinsicZYX(float zRadians, float yRadians, float xRadians)
             {
-                double sz = Math.Sin( zRadians * 0.5f );
-                double cz = Math.Cos( zRadians * 0.5f );
-                double sy = Math.Sin( yRadians * 0.5f );
-                double cy = Math.Cos( yRadians * 0.5f );
-                double sx = Math.Sin( xRadians * 0.5f );
-                double cx = Math.Cos( xRadians * 0.5f );
+                double sz = Math.Sin(zRadians * 0.5f);
+                double cz = Math.Cos(zRadians * 0.5f);
+                double sy = Math.Sin(yRadians * 0.5f);
+                double cy = Math.Cos(yRadians * 0.5f);
+                double sx = Math.Sin(xRadians * 0.5f);
+                double cx = Math.Cos(xRadians * 0.5f);
 
                 return new Quaternion
                 {
-                    W = (float)(  (cx * cy * cz) + (sx * sy * sz) ),
-                    X = (float)(  (sx * cy * cz) - (cx * sy * sz) ),
-                    Y = (float)(  (cx * sy * cz) + (sx * cy * sz) ),
-                    Z = (float)( -(sx * sy * cz) + (cx * cy * sz) ),
+                    W = (float)((cx * cy * cz) + (sx * sy * sz)),
+                    X = (float)((sx * cy * cz) - (cx * sy * sz)),
+                    Y = (float)((cx * sy * cz) + (sx * cy * sz)),
+                    Z = (float)(-(sx * sy * cz) + (cx * cy * sz)),
                 };
             }
         }
@@ -73,9 +73,9 @@ namespace NaturalPoint.TrackIR
             public float Y;
             public float Z;
 
-            public static readonly Vector3 Zero = new Vector3( 0.0f, 0.0f, 0.0f );
+            public static readonly Vector3 Zero = new Vector3(0.0f, 0.0f, 0.0f);
 
-            public Vector3( float x, float y, float z )
+            public Vector3(float x, float y, float z)
             {
                 X = x;
                 Y = y;
@@ -94,13 +94,13 @@ namespace NaturalPoint.TrackIR
         {
         }
 
-        public TrackIRException( string message )
-            : base( message )
+        public TrackIRException(string message)
+            : base(message)
         {
         }
 
-        public TrackIRException( string message, Exception inner )
-            : base( message, inner )
+        public TrackIRException(string message, Exception inner)
+            : base(message, inner)
         {
         }
     }

--- a/Assets/TrackIR/TrackIR/Native.cs
+++ b/Assets/TrackIR/TrackIR/Native.cs
@@ -58,14 +58,14 @@ namespace NaturalPoint.TrackIR
     /// To be consistent with the TrackIR 5 software viewport, they should be applied in the order z-y'-x'' (R-Y-P).
     /// The values range from -16383.0f to 16383.0f, and map to a range of -180 degrees to +180 degrees.
     /// </remarks>
-    [StructLayout( LayoutKind.Sequential, Pack = 1 )]
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
     public struct TrackIRData
     {
-        public UInt16 Status; 				// Tells us whether or not the TrackIR camera is in mouse-emulation (cursor control) mode or not 
-											// Status = 0 means the remote interface is enabled (ie no mouse-emulation)
-											// Status = 1 means we are in mouse-emulation mode
-											// (this could result in weird behavior in the game, its best to not update the position when this is enabled)
-											
+        public UInt16 Status;               // Tells us whether or not the TrackIR camera is in mouse-emulation (cursor control) mode or not 
+                                            // Status = 0 means the remote interface is enabled (ie no mouse-emulation)
+                                            // Status = 1 means we are in mouse-emulation mode
+                                            // (this could result in weird behavior in the game, its best to not update the position when this is enabled)
+
         public UInt16 FrameSignature;		// Incrementing frame number coming from the TrackIR app used to verify if the incoming frame is new. Ranges from 1 to 32766
         public UInt32 IOData;				// only used for hash key encryption on a few games. It is likely you won't need to use this.
 
@@ -77,8 +77,8 @@ namespace NaturalPoint.TrackIR
         public float Z;
 
         // This approach renders the struct non-blittable and leads to GC alloc during marshalling...
-//      [MarshalAs( UnmanagedType.ByValArray, ArraySubType = UnmanagedType.R4, SizeConst = 9 )]
-//      private float[] Reserved;
+        //      [MarshalAs( UnmanagedType.ByValArray, ArraySubType = UnmanagedType.R4, SizeConst = 9 )]
+        //      private float[] Reserved;
 
         // ...whereas this more verbose approach avoids generating any garbage.
         private float Reserved1;
@@ -97,13 +97,13 @@ namespace NaturalPoint.TrackIR
     /// This structure contains strings set by both the TrackIR Enhanced DLL and the TrackIR application itself. Used
     /// for integrity checking.
     /// </summary>
-    [StructLayout( LayoutKind.Sequential, Pack = 1, CharSet = CharSet.Ansi )]
+    [StructLayout(LayoutKind.Sequential, Pack = 1, CharSet = CharSet.Ansi)]
     public struct TrackIRSignature
     {
-        [MarshalAs( UnmanagedType.ByValTStr, SizeConst = 200 )]
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 200)]
         public string DllSignature;
 
-        [MarshalAs( UnmanagedType.ByValTStr, SizeConst = 200 )]
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 200)]
         public string AppSignature;
     }
 
@@ -117,34 +117,34 @@ namespace NaturalPoint.TrackIR
     /// </remarks>
     public class NativeClientLibrary
     {
-        [UnmanagedFunctionPointer( CallingConvention.StdCall )]
-        public delegate NPResult NP_RegisterWindowHandle_Delegate( IntPtr hwnd );
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        public delegate NPResult NP_RegisterWindowHandle_Delegate(IntPtr hwnd);
 
-        [UnmanagedFunctionPointer( CallingConvention.StdCall )]
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         public delegate NPResult NP_UnregisterWindowHandle_Delegate();
 
-        [UnmanagedFunctionPointer( CallingConvention.StdCall )]
-        public delegate NPResult NP_RegisterProgramProfileID_Delegate( UInt16 ppid );
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        public delegate NPResult NP_RegisterProgramProfileID_Delegate(UInt16 ppid);
 
-        [UnmanagedFunctionPointer( CallingConvention.StdCall )]
-        public delegate NPResult NP_QueryVersion_Delegate( out UInt16 version );
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        public delegate NPResult NP_QueryVersion_Delegate(out UInt16 version);
 
-        [UnmanagedFunctionPointer( CallingConvention.StdCall )]
-        public delegate NPResult NP_GetSignature_Delegate( ref TrackIRSignature signature );
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        public delegate NPResult NP_GetSignature_Delegate(ref TrackIRSignature signature);
 
-        [UnmanagedFunctionPointer( CallingConvention.StdCall )]
-        public delegate NPResult NP_GetData_Delegate( ref TrackIRData data );
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        public delegate NPResult NP_GetData_Delegate(ref TrackIRData data);
 
-        [UnmanagedFunctionPointer( CallingConvention.StdCall )]
-        public delegate NPResult NP_GetDataEX_Delegate( ref TrackIRData data, UInt32 AppKeyHigh, UInt32 AppKeyLow );
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        public delegate NPResult NP_GetDataEX_Delegate(ref TrackIRData data, UInt32 AppKeyHigh, UInt32 AppKeyLow);
 
-        [UnmanagedFunctionPointer( CallingConvention.StdCall )]
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         public delegate NPResult NP_ReCenter_Delegate();
 
-        [UnmanagedFunctionPointer( CallingConvention.StdCall )]
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         public delegate NPResult NP_StartDataTransmission_Delegate();
 
-        [UnmanagedFunctionPointer( CallingConvention.StdCall )]
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         public delegate NPResult NP_StopDataTransmission_Delegate();
 
 
@@ -165,10 +165,10 @@ namespace NaturalPoint.TrackIR
         public NativeClientLibrary()
         {
             // Load TrackIR Enhanced client dynamic library.
-            m_hLibrary = NativeMethods.LoadLibrary( GetLibraryLocation() );
-            if ( m_hLibrary == IntPtr.Zero )
+            m_hLibrary = NativeMethods.LoadLibrary(GetLibraryLocation());
+            if (m_hLibrary == IntPtr.Zero)
             {
-                throw new TrackIRException( "Error loading TrackIR client library.", new Win32Exception( Marshal.GetLastWin32Error() ) );
+                throw new TrackIRException("Error loading TrackIR client library.", new Win32Exception(Marshal.GetLastWin32Error()));
             }
 
             // Find exported functions in loaded library.
@@ -178,11 +178,11 @@ namespace NaturalPoint.TrackIR
 
         ~NativeClientLibrary()
         {
-            if ( m_hLibrary != IntPtr.Zero )
+            if (m_hLibrary != IntPtr.Zero)
             {
-                if ( ! NativeMethods.FreeLibrary( m_hLibrary ) )
+                if (!NativeMethods.FreeLibrary(m_hLibrary))
                 {
-                    Console.WriteLine( "Error unloading client library: {0}", new Win32Exception( Marshal.GetLastWin32Error() ).Message );
+                    Console.WriteLine("Error unloading client library: {0}", new Win32Exception(Marshal.GetLastWin32Error()).Message);
                 }
             }
         }
@@ -190,7 +190,7 @@ namespace NaturalPoint.TrackIR
 
         private string GetLibraryLocation()
         {
-			// NOTE: Imports the DLL from registered directory. Program Files (x86) by default.
+            // NOTE: Imports the DLL from registered directory. Program Files (x86) by default.
             const string kLibraryLocationRegistryKey = "HKEY_CURRENT_USER\\Software\\NaturalPoint\\NaturalPoint\\NPClient Location";
             const string kLibraryLocationSubkey = "Path";
 
@@ -198,11 +198,11 @@ namespace NaturalPoint.TrackIR
 
             try
             {
-                libraryPath = (string)Microsoft.Win32.Registry.GetValue( kLibraryLocationRegistryKey, kLibraryLocationSubkey, "" );
+                libraryPath = (string)Microsoft.Win32.Registry.GetValue(kLibraryLocationRegistryKey, kLibraryLocationSubkey, "");
             }
-            catch ( Exception ex )
+            catch (Exception ex)
             {
-                throw new TrackIRException( "Exception trying to read client library location from registry.", ex );
+                throw new TrackIRException("Exception trying to read client library location from registry.", ex);
             }
 
             libraryPath += "\\";
@@ -215,36 +215,36 @@ namespace NaturalPoint.TrackIR
         private void FindAllLibraryFunctions()
         {
             // This code is more verbose/less generic than I would like, largely owing to the fact that System.Delegate cannot be used as a generic constraint on FindLibraryFunction<T>.
-            NP_RegisterWindowHandle = (NP_RegisterWindowHandle_Delegate)FindLibraryFunction<NP_RegisterWindowHandle_Delegate>( "NP_RegisterWindowHandle" );
-            NP_UnregisterWindowHandle = (NP_UnregisterWindowHandle_Delegate)FindLibraryFunction<NP_UnregisterWindowHandle_Delegate>( "NP_UnregisterWindowHandle" );
-            NP_RegisterProgramProfileID = (NP_RegisterProgramProfileID_Delegate)FindLibraryFunction<NP_RegisterProgramProfileID_Delegate>( "NP_RegisterProgramProfileID" );
-            NP_QueryVersion = (NP_QueryVersion_Delegate)FindLibraryFunction<NP_QueryVersion_Delegate>( "NP_QueryVersion" );
-            NP_GetSignature = (NP_GetSignature_Delegate)FindLibraryFunction<NP_GetSignature_Delegate>( "NP_GetSignature" );
-            NP_GetData = (NP_GetData_Delegate)FindLibraryFunction<NP_GetData_Delegate>( "NP_GetData" );
+            NP_RegisterWindowHandle = (NP_RegisterWindowHandle_Delegate)FindLibraryFunction<NP_RegisterWindowHandle_Delegate>("NP_RegisterWindowHandle");
+            NP_UnregisterWindowHandle = (NP_UnregisterWindowHandle_Delegate)FindLibraryFunction<NP_UnregisterWindowHandle_Delegate>("NP_UnregisterWindowHandle");
+            NP_RegisterProgramProfileID = (NP_RegisterProgramProfileID_Delegate)FindLibraryFunction<NP_RegisterProgramProfileID_Delegate>("NP_RegisterProgramProfileID");
+            NP_QueryVersion = (NP_QueryVersion_Delegate)FindLibraryFunction<NP_QueryVersion_Delegate>("NP_QueryVersion");
+            NP_GetSignature = (NP_GetSignature_Delegate)FindLibraryFunction<NP_GetSignature_Delegate>("NP_GetSignature");
+            NP_GetData = (NP_GetData_Delegate)FindLibraryFunction<NP_GetData_Delegate>("NP_GetData");
             try
             {
-                NP_GetDataEX = (NP_GetDataEX_Delegate)FindLibraryFunction< NP_GetDataEX_Delegate > ("NP_GetDataEX");
+                NP_GetDataEX = (NP_GetDataEX_Delegate)FindLibraryFunction<NP_GetDataEX_Delegate>("NP_GetDataEX");
             }
-            catch(TrackIRException)
+            catch (TrackIRException)
             {
                 Console.WriteLine("NP_GetDataEX not found. Must be using old version of SDK. This function is not available to use.");
             }
-            NP_ReCenter = (NP_ReCenter_Delegate)FindLibraryFunction<NP_ReCenter_Delegate>( "NP_ReCenter" );
-            NP_StartDataTransmission = (NP_StartDataTransmission_Delegate)FindLibraryFunction<NP_StartDataTransmission_Delegate>( "NP_StartDataTransmission" );
-            NP_StopDataTransmission = (NP_StopDataTransmission_Delegate)FindLibraryFunction<NP_StopDataTransmission_Delegate>( "NP_StopDataTransmission" );
+            NP_ReCenter = (NP_ReCenter_Delegate)FindLibraryFunction<NP_ReCenter_Delegate>("NP_ReCenter");
+            NP_StartDataTransmission = (NP_StartDataTransmission_Delegate)FindLibraryFunction<NP_StartDataTransmission_Delegate>("NP_StartDataTransmission");
+            NP_StopDataTransmission = (NP_StopDataTransmission_Delegate)FindLibraryFunction<NP_StopDataTransmission_Delegate>("NP_StopDataTransmission");
         }
 
 
-        private Delegate FindLibraryFunction<T>( string functionName )
+        private Delegate FindLibraryFunction<T>(string functionName)
         {
-            IntPtr pfn = NativeMethods.GetProcAddress( m_hLibrary, functionName );
-            if ( pfn == IntPtr.Zero )
+            IntPtr pfn = NativeMethods.GetProcAddress(m_hLibrary, functionName);
+            if (pfn == IntPtr.Zero)
             {
-                throw new TrackIRException( "Error locating client library function " + functionName + ".", new Win32Exception( Marshal.GetLastWin32Error() ) );
+                throw new TrackIRException("Error locating client library function " + functionName + ".", new Win32Exception(Marshal.GetLastWin32Error()));
             }
             else
             {
-                return Marshal.GetDelegateForFunctionPointer( pfn, typeof( T ) );
+                return Marshal.GetDelegateForFunctionPointer(pfn, typeof(T));
             }
         }
     }
@@ -252,13 +252,13 @@ namespace NaturalPoint.TrackIR
 
     internal static class NativeMethods
     {
-        [DllImport( "kernel32.dll", SetLastError = true )]
-        public static extern IntPtr LoadLibrary( string fileName );
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr LoadLibrary(string fileName);
 
-        [DllImport( "kernel32.dll", SetLastError = true )]
-        public static extern IntPtr GetProcAddress( IntPtr hModule, string procedureName );
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr GetProcAddress(IntPtr hModule, string procedureName);
 
-        [DllImport( "kernel32.dll", SetLastError = true )]
-        public static extern bool FreeLibrary( IntPtr hModule );
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool FreeLibrary(IntPtr hModule);
     }
 }


### PR DESCRIPTION
Description: 
This adds the second method of rotating the player and adds TrackIR head gesture controls to make the player jump. The second rotation method allows the user to rotate their head on the yaw axis (nodding left and right) past a threshold to rotate the player left or right. 
The head gesture implemented makes the player jump when they quickly nod straight up.
The head gesture controls store the past 30 frames of head tracking data in a queue. Every frame the new data is enqueued until the queue length is 30 then it also dequeues the head data at the front to keep a constant length.
It then goes through each item, checking if any of them have a yaw axis outside the threshold. 
If the current head data has a yaw rotation past a certain threshold then the user did not nod straight enough and the loop will be broken.
If the current data shows a pitch value under a threshold, as in they aren't looking upwards already, then a boolean `canJump` is marked true.
If `canJump` is true and the current data shows a pitch value above a certain threshold, then if the player is on the ground we make the player jump.

Added a FPS lock to create a known FPS so we know the time frame the user has to trigger the gesture.